### PR TITLE
Restore button backlight controls

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8996-v3-pmi8996-comma-leeco.dts
+++ b/arch/arm/boot/dts/qcom/msm8996-v3-pmi8996-comma-leeco.dts
@@ -729,3 +729,30 @@
 		};
 	};
 };
+
+&spmi_bus {
+	qcom,pm8994@0 {
+		/* configure pm8994 MPP2 as back-light of touch key */
+		touch_key_led: qcom,leds@a100 {
+			compatible = "qcom,leds-qpnp";
+			reg = <0xa100 0x100>;
+			status = "okay";
+
+			mpp-power-supply = <&pm8994_l22>;
+			qcom,mpp-power-max-voltage = <3300000>;
+			qcom,mpp-power-min-voltage = <3300000>;
+			qcom,led_mpp_2 {
+				label = "mpp";
+				linux,name = "button-backlight";
+				linux,default-trigger = "none";
+				qcom,default-state = "off";
+				qcom,current-setting = <5>;
+				qcom,max-current = <40>;
+				qcom,id = <6>;
+				qcom,source-sel = <1>;
+				qcom,mode-ctrl = <0x60>; /* current sink mode */
+				qcom,mode = "manual";
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/qcom/msm8996-v3-pmi8996-comma-oneplus.dts
+++ b/arch/arm/boot/dts/qcom/msm8996-v3-pmi8996-comma-oneplus.dts
@@ -751,4 +751,24 @@
 			/delete-node/ qcom,pon_3;
 		};
 	};
+    qcom,pmi8994@2 {
+        qcom,leds@a300 {
+            compatible = "qcom,leds-qpnp";
+            reg = <0xa300 0x100>;
+            status = "okay";
+
+            qcom,led_mpp_4 {
+                label = "mpp";
+                linux,name = "button-backlight";
+                linux,default-trigger = "none";
+                qcom,default-state = "off";
+                qcom,max-current = <40>;
+                qcom,current-setting = <5>;
+                qcom,id = <6>;
+                qcom,mode = "manual";
+                qcom,source-sel = <1>;
+                qcom,mode-ctrl = <0x60>;
+            };
+        };
+    };
 };

--- a/arch/arm/boot/dts/qcom/msm8996pro-pmi8996-comma-leeco.dts
+++ b/arch/arm/boot/dts/qcom/msm8996pro-pmi8996-comma-leeco.dts
@@ -787,3 +787,30 @@
 		};
 	};
 };
+
+&spmi_bus {
+	qcom,pm8994@0 {
+		/* configure pm8994 MPP2 as back-light of touch key */
+		touch_key_led: qcom,leds@a100 {
+			compatible = "qcom,leds-qpnp";
+			reg = <0xa100 0x100>;
+			status = "okay";
+
+			mpp-power-supply = <&pm8994_l22>;
+			qcom,mpp-power-max-voltage = <3300000>;
+			qcom,mpp-power-min-voltage = <3300000>;
+			qcom,led_mpp_2 {
+				label = "mpp";
+				linux,name = "button-backlight";
+				linux,default-trigger = "none";
+				qcom,default-state = "off";
+				qcom,current-setting = <5>;
+				qcom,max-current = <40>;
+				qcom,id = <6>;
+				qcom,source-sel = <1>;
+				qcom,mode-ctrl = <0x60>; /* current sink mode */
+				qcom,mode = "manual";
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/qcom/msm8996pro-pmi8996-comma-oneplus.dts
+++ b/arch/arm/boot/dts/qcom/msm8996pro-pmi8996-comma-oneplus.dts
@@ -810,4 +810,24 @@
 			/delete-node/ qcom,pon_3;
 		};
 	};
+    qcom,pmi8994@2 {
+        qcom,leds@a300 {
+            compatible = "qcom,leds-qpnp";
+            reg = <0xa300 0x100>;
+            status = "okay";
+
+            qcom,led_mpp_4 {
+                label = "mpp";
+                linux,name = "button-backlight";
+                linux,default-trigger = "none";
+                qcom,default-state = "off";
+                qcom,max-current = <40>;
+                qcom,current-setting = <5>;
+                qcom,id = <6>;
+                qcom,mode = "manual";
+                qcom,source-sel = <1>;
+                qcom,mode-ctrl = <0x60>;
+            };
+        };
+    };
 };


### PR DESCRIPTION
Pick up the relevant MPP configs from the pre-unified LeEco and OP3T kernels to expose button backlight controls to userspace. Resolves commaai/eon-neos-builder#17