### PR TITLE
Restore normal framebuffer power controls

### DIFF
--- a/drivers/comma/leeco/touchscreen/synaptics_dsx_core.c
+++ b/drivers/comma/leeco/touchscreen/synaptics_dsx_core.c
@@ -4474,8 +4474,15 @@ static int synaptics_rmi4_fb_notifier_cb(struct notifier_block *self,
 	if (evdata && evdata->data && rmi4_data) {
 		if (event == FB_EVENT_BLANK) {
 			transition = evdata->data;
-			if (*transition == FB_BLANK_UNBLANK)
+			if (*transition == FB_BLANK_POWERDOWN) {
+        pr_warn("hacked to NOT call synaptics_rmi4_suspend\n");
+				/*if(flush_work(&rmi4_data->fb_notify_work))
+					pr_warn("%s: waited resume work finished!\n",__func__);
+				synaptics_rmi4_suspend(&rmi4_data->pdev->dev);
+				rmi4_data->fb_ready = false;*/
+			} else if (*transition == FB_BLANK_UNBLANK) {
 				schedule_work(&rmi4_data->fb_notify_work);
+			}
 		}
 	}
 

--- a/drivers/comma/leeco/touchscreen/synaptics_dsx_core.c
+++ b/drivers/comma/leeco/touchscreen/synaptics_dsx_core.c
@@ -64,7 +64,7 @@
 #define TYPE_B_PROTOCOL
 #endif
 
-#define WAKEUP_GESTURE false
+#define WAKEUP_GESTURE true
 
 #define SYNAPTICS_CLASS_NAME      "synaptics_fp"
 #define TP_STATUS_OK   1

--- a/drivers/comma/leeco/touchscreen/synaptics_dsx_core.c
+++ b/drivers/comma/leeco/touchscreen/synaptics_dsx_core.c
@@ -4475,11 +4475,10 @@ static int synaptics_rmi4_fb_notifier_cb(struct notifier_block *self,
 		if (event == FB_EVENT_BLANK) {
 			transition = evdata->data;
 			if (*transition == FB_BLANK_POWERDOWN) {
-        pr_warn("hacked to NOT call synaptics_rmi4_suspend\n");
-				/*if(flush_work(&rmi4_data->fb_notify_work))
+				if(flush_work(&rmi4_data->fb_notify_work))
 					pr_warn("%s: waited resume work finished!\n",__func__);
 				synaptics_rmi4_suspend(&rmi4_data->pdev->dev);
-				rmi4_data->fb_ready = false;*/
+				rmi4_data->fb_ready = false;
 			} else if (*transition == FB_BLANK_UNBLANK) {
 				schedule_work(&rmi4_data->fb_notify_work);
 			}

--- a/drivers/comma/oneplus/touchscreen/synaptics_driver_s3320.c
+++ b/drivers/comma/oneplus/touchscreen/synaptics_driver_s3320.c
@@ -2672,10 +2672,23 @@ static int fb_notifier_callback(struct notifier_block *self, unsigned long event
 	if (event != FB_EARLY_EVENT_BLANK)
 		return NOTIFY_OK;
 
-	if (*blank == FB_BLANK_UNBLANK && ts->screen_off) {
-		cancel_work_sync(&ts->pm_work);
-		ts->screen_off = 0;
-		queue_work(system_highpri_wq, &ts->pm_work);
+	switch (*blank) {
+	case FB_BLANK_UNBLANK:
+	case FB_BLANK_VSYNC_SUSPEND:
+	case FB_BLANK_NORMAL:
+		if (ts->screen_off) {
+			cancel_work_sync(&ts->pm_work);
+			ts->screen_off = 0;
+			queue_work(system_highpri_wq, &ts->pm_work);
+		}
+		break;
+	case FB_BLANK_POWERDOWN:
+		if (!ts->screen_off) {
+			cancel_work_sync(&ts->pm_work);
+			ts->screen_off = 1;
+			queue_work(system_highpri_wq, &ts->pm_work);
+		}
+		break;
 	}
 
 	return NOTIFY_OK;

--- a/drivers/video/msm/mdss/mdss_fb.c
+++ b/drivers/video/msm/mdss/mdss_fb.c
@@ -1954,11 +1954,6 @@ static int mdss_fb_blank(int blank_mode, struct fb_info *info)
 		return ret;
 	}
 
-#ifdef CONFIG_MACH_COMMA
-	if (blank_mode != FB_BLANK_UNBLANK)
-		blank_mode = BLANK_FLAG_LP;
-#endif
-
 	if (mfd->op_enable == 0) {
 		if (blank_mode == FB_BLANK_UNBLANK)
 			mfd->suspend.panel_power_state = MDSS_PANEL_POWER_ON;

--- a/drivers/video/msm/mdss/mdss_fb.c
+++ b/drivers/video/msm/mdss/mdss_fb.c
@@ -1192,11 +1192,6 @@ static int mdss_fb_probe(struct platform_device *pdev)
 	mutex_init(&mfd->bl_lock);
 	mutex_init(&mfd->switch_lock);
 
-#ifdef CONFIG_MACH_COMMA
-	if (!strstr(saved_command_line, "androidboot.mode=recovery"))
-		mfd->is_comma_neos = true;
-#endif
-
 	fbi_list[fbi_list_index++] = fbi;
 
 	platform_set_drvdata(pdev, mfd);
@@ -1960,7 +1955,7 @@ static int mdss_fb_blank(int blank_mode, struct fb_info *info)
 	}
 
 #ifdef CONFIG_MACH_COMMA
-	if (mfd->is_comma_neos && blank_mode != FB_BLANK_UNBLANK)
+	if (blank_mode != FB_BLANK_UNBLANK)
 		blank_mode = BLANK_FLAG_LP;
 #endif
 

--- a/drivers/video/msm/mdss/mdss_fb.h
+++ b/drivers/video/msm/mdss/mdss_fb.h
@@ -360,9 +360,6 @@ struct msm_fb_data_type {
 	bool pending_switch;
 	struct mutex switch_lock;
 	struct input_handler *input_handler;
-#ifdef CONFIG_MACH_COMMA
-	bool is_comma_neos;
-#endif
 };
 
 static inline void mdss_fb_update_notify_update(struct msm_fb_data_type *mfd)


### PR DESCRIPTION
Requires a companion update to openpilot/UI to keep touchscreen working.