### PR TITLE
Fix for bootloops

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8996-regulator.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8996-regulator.dtsi
@@ -586,7 +586,8 @@
 		qcom,cpr-count-repeat = <25>;
 
 		qcom,apm-ctrl = <&apc_apm>;
-		qcom,apm-threshold-voltage = <850000>;
+		//qcom,apm-threshold-voltage = <850000>;
+		qcom,apm-threshold-voltage = <0>;   /* Switch to use VDD_APCC instead of VDD_MX always */
 		qcom,apm-hysteresis-voltage = <5000>;
 		qcom,system-supply-max-voltage = <1015000>;
 		qcom,mem-acc-supply-threshold-voltage = <700000>;


### PR DESCRIPTION
so bootloops turn out to be interesting, and not exactly core voltage related.

there's a function cpr3_regulator_switch_apm_mode which can switch the core supply from VDD_APCC to VDD_MX. the VDD_MX on this phone seems broken, like the cores die as soon as the switch happens

the threshold for this function is 0.85v, hence why above that fixes it. though I don't see why I actually have to switch it, i'm running at the lower voltage on VDD_APCC fine