### PR TITLE
Lock Kryo regulator in BHS mode

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8996-regulator.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8996-regulator.dtsi
@@ -640,6 +640,7 @@
 				qcom,ldo-min-headroom-voltage = <150000>;
 				qcom,ldo-max-headroom-voltage = <470000>;
 				qcom,ldo-max-voltage = <890000>;
+				qcom,ldo-disable;
 				qcom,uses-mem-acc;
 
 				qcom,cpr-corner-fmax-map =
@@ -1260,6 +1261,7 @@
 				qcom,ldo-min-headroom-voltage = <150000>;
 				qcom,ldo-max-headroom-voltage = <470000>;
 				qcom,ldo-max-voltage = <890000>;
+				qcom,ldo-disable;
 				qcom,uses-mem-acc;
 
 				qcom,cpr-corner-fmax-map =


### PR DESCRIPTION
This change appears to rescue some boot-looping devices, with success on three of three devices attempted so far. Affected devices will go into fastboot, but not into recovery or normal startup. In the broken state, the device boots up normally until the point CPR3 attempts to do aging measurements, at which point the device freezes and restarts.

Example broken startup from serial console: [01-bad-leeco-boot-initial-state.log](https://github.com/commaai/android_kernel_comma_msm8996/files/8157535/01-bad-leeco-boot-initial-state.log)

Example working startup after this patch: [05-bad-leeco-successful-boot-ldo-disable.log](https://github.com/commaai/android_kernel_comma_msm8996/files/8157542/05-bad-leeco-successful-boot-ldo-disable.log)
 
As a quick test to see if this patch will work on an affected device, here is a stripped-down NEOS updater that just flashes a patched boot and recovery kernel: https://github.com/jyoung8607/juice-me

I can't completely describe how this change works, or what its effects might be, but it seems relatively safe to run this way considering the Qualcomm developers themselves ran MSM8996 in BHS mode (block head switch vs LDO low-dropout regulator) during [early development](https://github.com/commaai/android_kernel_comma_msm8996/commit/6bd17f7af6ffb7cc87fec04ff16fcfb6954726c2).

Looking at `/sys/kernel/debug/kryo-regulator/kryo[01]/mode`, it sure looks like both healthy and loop-patched LeEcos are running in BHS mode at comma's locked frequency. I also don't see a major change at the upstream switchmode regulator `/sys/kernel/debug/regulator/pm8994_s11/voltage`, 725000 vs 730000 microvolts on healthy vs loop-patched. So, except to sneak around the problem at the moment of CPR3 aging measurement, there may be no real change.